### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Pipeline
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/jacklowrie/chordnet/security/code-scanning/2](https://github.com/jacklowrie/chordnet/security/code-scanning/2)

To address the issue, add a `permissions` block restricting the GITHUB_TOKEN's access. The CodeQL recommendation is to start with `permissions: { contents: read }`, which allows Actions to fetch repository contents but not to perform write actions (such as modifying releases, issues, or committing code).

This should be added near the top, either at the workflow root (applies to all jobs and is preferred for simplicity), or within each individual job if different scopes are needed per job (not required here).  
**Change to make:**  
- Insert the block:
  ```yaml
  permissions:
    contents: read
  ```
  immediately after the `name: Pipeline` line (line 4).

No additional methods, imports, or special constructs are needed—just an added `permissions` section in the YAML. No dependencies or further edits are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
