### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Main Branch QA
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jacklowrie/chordnet/security/code-scanning/1](https://github.com/jacklowrie/chordnet/security/code-scanning/1)

To fix this problem, add an explicit `permissions` block near the top of `.github/workflows/main.yml`. For minimal required access, start with `contents: read`, which means workflows can only read repository contents (not write). This should be placed at the workflow root, just below the `name` key and before `on:`. This will ensure that all jobs, including those that invoke reusable workflows, have the correct least-privilege permissions by default, unless further restricted or expanded in jobs or the called workflow.

No additional methods, imports, or definitions are needed since this is a YAML configuration change. Be careful to place the block in the correct location to apply it globally to all jobs unless overridden locally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
